### PR TITLE
feat: allow specifying uid and gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apt update \
     && apt install -y jq \
     && rm -rf /var/lib/apt/lists/*
 
+RUN adduser --disabled-password --uid 1000 --shell /bin/bash --gecos "" minecraft \
+    && addgroup minecraft users
+
 EXPOSE 25565
 
 WORKDIR /minecraft

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,22 @@ set -e
 
 JAR_NAME="server-${MINECRAFT_VERSION}.jar"
 
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+USER=${USER:-"minecraft"}
+
+if [ ! "$(id -u "${USER}")" -eq "$PUID" ]; then usermod -o -u "$PUID" "${USER}" ; fi
+if [ ! "$(id -g "${USER}")" -eq "$PGID" ]; then groupmod -o -g "$PGID" "${USER}" ; fi
+
+echo "
+-----------------------------------
+GID/UID
+-----------------------------------
+User uid:    $(id -u "${USER}")
+User gid:    $(id -g "${USER}")
+-----------------------------------
+"
+
 if [ ! -f "$JAR_NAME" ]; then
     echo "Downloading Minecraft";
 
@@ -18,4 +34,9 @@ fi
 echo "Accepting EULA"
 echo "eula=true" > eula.txt
 
-java ${JAVA_OPTS} -jar "$JAR_NAME" nogui
+chown -R "${USER}":"${USER}" /minecraft
+
+
+COMMAND="${*:-"cd /minecraft; $(which java) ${JAVA_OPTS} -jar $JAR_NAME nogui"}"
+
+su -l "${USER}" -c "$COMMAND"


### PR DESCRIPTION
This PR introduces mapping `PUID` and `PGID` to the current user of the docker container, allowing permissions to be correctly maintained between container and host.