### PR TITLE
feat: allow configuring server.properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ ENV MINECRAFT_VERSION=1.20.2
 ENV JAVA_OPTS="-Xms1G -Xmx2G"
 
 COPY entrypoint.sh /entrypoint.sh
+COPY ./set-up-user.sh /usr/local/bin/set-up-user.sh
+COPY ./configure-server-properties.sh /usr/local/bin/configure-server-properties.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# [anthonyporthouse/minecraft-server](https://github.com/anthonyporthouse/minecraft-server)
+
+## Tags
+
+The major tags determine which version of java you will be using to run minecraft.
+
+- `java8`
+- `java11`
+- `java16`
+- `java17`
+
+## Usage
+
+### docker-compose
+
+Example `docker-compose.yaml` file:
+
+```yaml
+---
+services:
+  minecraft:
+    image: ghcr.io/anthonyporthouse/minecraft-server:java17
+
+    restart: unless-stopped
+
+    environment:
+      PUID: 1000
+      PGID: 1000
+
+      MINECRAFT_VERSION: 1.20.2
+      JAVA_OPTS: -Xms1G -Xmx2G
+
+      MC_DIFFICULTY: hard
+      MC_MOTD: My Server
+    
+    ports:
+      - "25565:25565"
+    
+    volumes:
+      - ./server:/minecraft
+
+```
+
+### Environment Variables
+
+To make this image more useful several environment variables are available to use.
+
+**`PUID`**
+
+> Default Value: `1000`
+
+This environment variable specifies the ID to use for the minecraft user inside of the container.
+
+This should map to the current users UID which can be found using `id -u` on Linux or Mac.
+
+**`PGID`**
+
+> Default Value: `1000`
+
+This environment variable specifies the ID to use for the minecraft group inside of the container.
+
+This should map to the current users GID which can be found using `id -g` on Linux or Mac.
+
+**`MINECRAFT_VERSION`**
+
+> Default Value: `1.20.2`
+
+This environment variable specifies which version of Minecraft you wish to run. This can be any version supported, either stable or prerelease.
+
+If this is changed after an initial run the container will pull the new version and use that.
+
+**`JAVA_OPTS`**
+
+> Default Value: `-Xms1G -Xmx2G`
+
+This environment variable allows you to specify custom JVM arguments when running minecraft.
+
+**`MC_*`**
+
+Any environment variable that is prefixed with `MC_` will have its prefix removed, be lowercased and have any `_` replaced with `-` then be either replaced, or appended to the `server.properties` file.
+
+Example: `MC_MAX_PLAYERS` with value `10` sets the value of `max-players=10` in the `server.properties` file.

--- a/configure-server-properties.sh
+++ b/configure-server-properties.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+vars=("${!MC_@}")
+
+if [ ! -f /minecraft/server.properties ]; then 
+    echo "#" > /minecraft/server.properties
+fi
+
+for var in "${vars[@]}"; do
+
+    name=$(echo "$var" | tr '[:upper:]' '[:lower:]' | sed -e 's/^mc_//' -e 's/_/-/')
+    value=$(printenv "$var")
+
+    echo "$name=$value"
+
+    sed -i "/^$name=/{h;s/=.*/=$value/};\${x;/^$/{s//$name=$value/;H};x}" /minecraft/server.properties
+done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,17 +7,7 @@ PUID=${PUID:-1000}
 PGID=${PGID:-1000}
 USER=${USER:-"minecraft"}
 
-if [ ! "$(id -u "${USER}")" -eq "$PUID" ]; then usermod -o -u "$PUID" "${USER}" ; fi
-if [ ! "$(id -g "${USER}")" -eq "$PGID" ]; then groupmod -o -g "$PGID" "${USER}" ; fi
-
-echo "
------------------------------------
-GID/UID
------------------------------------
-User uid:    $(id -u "${USER}")
-User gid:    $(id -g "${USER}")
------------------------------------
-"
+set-up-user.sh "$USER" "$PUID" "$PGID"
 
 if [ ! -f "$JAR_NAME" ]; then
     echo "Downloading Minecraft";
@@ -33,6 +23,8 @@ fi
 
 echo "Accepting EULA"
 echo "eula=true" > eula.txt
+
+configure-server-properties.sh
 
 chown -R "${USER}":"${USER}" /minecraft
 

--- a/set-up-user.sh
+++ b/set-up-user.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+# Username/Groupname to use
+USER=$1
+
+# Target User ID
+PUID=$2
+
+# Target Group ID
+PGID=$3
+
+if [ ! "$(id -u "${USER}")" -eq "$PUID" ]; then usermod -o -u "$PUID" "${USER}" ; fi
+if [ ! "$(id -g "${USER}")" -eq "$PGID" ]; then groupmod -o -g "$PGID" "${USER}" ; fi
+
+echo "
+-----------------------------------
+GID/UID
+-----------------------------------
+User uid:    $(id -u "${USER}")
+User gid:    $(id -g "${USER}")
+-----------------------------------
+"


### PR DESCRIPTION
Configuring the server.properties file is managed by passing environment variables prefixed with `MC_`. The prefix is removed, any `_` are replaced with `-` and the value is lowercased to find the correct server.properties key.

For example: `MC_MAX_PLAYERS` becomes `max-players`

refactor: separate user configuration to a stand-alone script

This will allow this script to be moved elsewhere to simplify maintenance and allow for reusability.

docs: create readme file