### PR TITLE
fix: correct build issues with base image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,50 @@
+on:
+  - pull_request
+
+name: Test Build
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [21, 17, 16, 11, 8]
+
+    name: Test Build ${{ matrix.java-version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/anthonyporthouse/minecraft-server
+          flavor: |
+            prefix=java${{ matrix.java-version }}-
+          tags: |
+            type=sha
+            type=sha,prefix=
+
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            JAVA_VERSION=${{matrix.java-version}}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN apt update \
     && apt install -y jq \
     && rm -rf /var/lib/apt/lists/*
 
-RUN adduser --disabled-password --uid 1000 --shell /bin/bash --gecos "" minecraft \
-    && addgroup minecraft users
+RUN useradd --home-dir /minecraft --no-create-home --non-unique --uid 1000 --shell /bin/bash minecraft
 
 EXPOSE 25565
 


### PR DESCRIPTION
The underlying eclipse-temurin containers have upgraded to ubuntu:noble this has removed the adduser and addgroup commands which were used during the container build.

The resolution for this was to migrate to using the useradd command.